### PR TITLE
Fix true sharing with transTable.keys counter

### DIFF
--- a/hash.cpp
+++ b/hash.cpp
@@ -59,16 +59,12 @@ void Hash::add(Board &b, uint64_t data, int depth, uint8_t age) {
 
     // Decide whether to replace the entry
     // A more recent update to the same position should always be chosen
-    if ((node->slot1.zobristKey ^ node->slot1.data) == b.getZobristKey()) {
-        if (getHashAge(node->slot1.data) != age)
-            keys++;
+    if ((node->slot1.zobristKey ^ node->slot1.data) == b.getZobristKey())
         node->slot1.setEntry(b, data);
-    }
-    else if ((node->slot2.zobristKey ^ node->slot2.data) == b.getZobristKey()) {
-        if (getHashAge(node->slot2.data) != age)
-            keys++;
+    
+    else if ((node->slot2.zobristKey ^ node->slot2.data) == b.getZobristKey())
         node->slot2.setEntry(b, data);
-    }
+    
     // Replace an entry from a previous search space, or the lowest
     // depth entry with the new entry if the new entry's depth is higher
     else {
@@ -86,11 +82,8 @@ void Hash::add(Board &b, uint64_t data, int depth, uint8_t age) {
         if (score1 < -2 && score2 < -2)
             toReplace = NULL;
 
-        if (toReplace != NULL) {
-            if (getHashAge(toReplace->data) != age)
-                keys++;
+        if (toReplace != NULL) 
             toReplace->setEntry(b, data);
-        }
     }
 }
 
@@ -129,10 +122,20 @@ void Hash::init(uint64_t MB) {
     size >>= 1;
 
     table = (HashNode *) calloc(size,  sizeof(HashNode));
-    keys = 0;
 }
 
 void Hash::clear() {
     std::memset(table, 0, size * sizeof(HashNode));
-    keys = 0;
+}
+
+int Hash::estimateHashfull(uint8_t age) {
+    
+    int i, used = 0;
+    
+    for (i = 0; i < 2500 && i < (int64_t)size; i++) {
+        used += getHashAge((table + i)->slot1.data) == age;
+        used += getHashAge((table + i)->slot2.data) == age;
+    }
+    
+    return 1000 * used / (i * 2);
 }

--- a/hash.h
+++ b/hash.h
@@ -98,7 +98,6 @@ private:
     void init(uint64_t MB);
 
 public:
-    uint64_t keys;
 
     Hash(uint64_t MB);
     Hash(const Hash &other) = delete;
@@ -110,6 +109,7 @@ public:
     uint64_t getSize();
     void setSize(uint64_t MB);
     void clear();
+    int estimateHashfull(uint8_t age);
 };
 
 #endif

--- a/search.cpp
+++ b/search.cpp
@@ -366,8 +366,7 @@ void getBestMove(Board *b, int mode, int value, Move *bestMove, MoveList *movesT
                     cout << " time " << timeSoFar
                          << " nodes " << getNodes() << " nps " << nps
                          << " tbhits " << getTBHits()
-                         << " hashfull " << 1000 * transpositionTable.keys
-                                                 / transpositionTable.getSize()
+                         << " hashfull " << transpositionTable.estimateHashfull(searchParamsArray[0]->rootMoveNumber)
                          << " pv " << pvStr << endl;
 
                     aspAlpha = bestScore - deltaAlpha;
@@ -385,8 +384,7 @@ void getBestMove(Board *b, int mode, int value, Move *bestMove, MoveList *movesT
                     cout << " time " << timeSoFar
                          << " nodes " << getNodes() << " nps " << nps
                          << " tbhits " << getTBHits()
-                         << " hashfull " << 1000 * transpositionTable.keys
-                                                 / transpositionTable.getSize()
+                         << " hashfull " << transpositionTable.estimateHashfull(searchParamsArray[0]->rootMoveNumber)
                          << " pv " << pvStr << endl;
 
                     aspBeta = bestScore + deltaBeta;
@@ -422,8 +420,7 @@ void getBestMove(Board *b, int mode, int value, Move *bestMove, MoveList *movesT
                 cout << " time " << timeSoFar
                      << " nodes " << getNodes() << " nps " << nps
                      << " tbhits " << getTBHits()
-                     << " hashfull " << 1000 * transpositionTable.keys
-                                             / transpositionTable.getSize()
+                     << " hashfull " << transpositionTable.estimateHashfull(searchParamsArray[0]->rootMoveNumber)
                      << endl;
                 break;
             }
@@ -455,8 +452,7 @@ void getBestMove(Board *b, int mode, int value, Move *bestMove, MoveList *movesT
             cout << " time " << timeSoFar
                  << " nodes " << getNodes() << " nps " << nps
                  << " tbhits " << getTBHits()
-                 << " hashfull " << 1000 * transpositionTable.keys
-                                         / transpositionTable.getSize()
+                 << " hashfull " << transpositionTable.estimateHashfull(searchParamsArray[0]->rootMoveNumber)
                  << " pv " << pvStr << endl;
         }
         // End multiPV loop
@@ -523,9 +519,6 @@ void getBestMove(Board *b, int mode, int value, Move *bestMove, MoveList *movesT
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     printStatistics();
-
-    // Reset the hashfull counter
-    transpositionTable.keys = 0;
 
     // Output best move to UCI interface
     stopSignal = true;


### PR DESCRIPTION
As of now everytime a thread updates transTable.keys they invalidate the cache.
This fix removes the transTable.keys counter, (which is only used to compute hashfull)
And replaces it with an estimator by sampling the table for current entries

Quick NPS test with 32 cores and 2GB hash on a Ryzen 1950x
master nps at depth 26 : 15,260,663
patch  nps at depth 26 : 15,330,364

The nps difference is unlikely to be able to be tested as an elo gain without many threads and games

Note that this problem persists through the entire game, since you reset keys to be zero