### PR TITLE
Reduce scale factor for opposite colored bishops.

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -406,7 +406,7 @@ const int KING_TROPISM_VALUE = 18;
 
 // Scale factors for drawish endgames
 const int MAX_SCALE_FACTOR = 32;
-const int OPPOSITE_BISHOP_SCALING[2] = {15, 30};
+const int OPPOSITE_BISHOP_SCALING[2] = {14, 27};
 const int PAWNLESS_SCALING[4] = {3, 4, 7, 25};
 
 


### PR DESCRIPTION
OCB in midgame lead to a corresponding OCB endgame more often than desired imo.

3235-3179-3179 in 10000 games at 3+0.03 (1.95 +/- 5.45)
1402-1302-2296 in 5000 games at 15+0.15 (6.95 +/- 7.07)