### PR TITLE
No futility pruning on killer moves

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -964,9 +964,13 @@ int PVS(Board &b, int depth, int alpha, int beta, int threadID, bool isCutNode, 
         // Futility pruning
         // If we are already a decent amount of material below alpha, a quiet
         // move probably won't raise our prospects much, so don't bother
-        // q-searching it.
-        if (moveIsPrunable && bestScore > -INFTY
-         && pruneDepth <= 6 && staticEval <= alpha - FUTILITY_MARGIN[pruneDepth])
+        // q-searching it, unless it is one of our killer moves
+        if (moveIsPrunable 
+         && bestScore > -INFTY
+         && pruneDepth <= 6
+         && staticEval <= alpha - FUTILITY_MARGIN[pruneDepth]
+         && m != searchParams->killers[ssi->ply][0]
+         && m != searchParams->killers[ssi->ply][1])
             continue;
 
 


### PR DESCRIPTION
Tested this locally at 5s+.05s. 
My machine gets just over 1M nps when running the tests on all the cores
3401 - 3235 - 5550 [.507] 12186 Elo = +5.022
If this had been an SPRT[0,5], LLR would be at about 2.2 right here.

Obviously not a completely conclusive result. But do with it what you please :)