### PR TITLE
Reduce scale factors for opposite colored bishops

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -408,7 +408,7 @@ const int KING_TROPISM_VALUE = 18;
 
 // Scale factors for drawish endgames
 const int MAX_SCALE_FACTOR = 32;
-const int OPPOSITE_BISHOP_SCALING[2] = {15, 30};
+const int OPPOSITE_BISHOP_SCALING[2] = {14, 28};
 const int PAWNLESS_SCALING[4] = {3, 4, 7, 25};
 
 


### PR DESCRIPTION
Retest of this idea after "Tune midgame-endgame eval interface".

bench: 2167271
915-839-1246 in 3000 games at 6+0.06 (8.80 +/- 9.50)
254-231-515 in 1000 games at 30+0.3 (7.99 +/- 14.98)
(My TCs halved ~ your TCs.)

Let's hope you can replicate this time...