### PR TITLE
Change BISHOP_PAIR_VALUE usage and PAWNLESS_SCALING

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -187,16 +187,16 @@ int Eval::evaluate(Board &b) {
 
     // Material
     int whiteMaterial = 0, blackMaterial = 0;
-    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++)
+    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++) {
         whiteMaterial += PIECE_VALUES[MG][pieceID] * pieceCounts[WHITE][pieceID];
-    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++)
         blackMaterial += PIECE_VALUES[MG][pieceID] * pieceCounts[BLACK][pieceID];
+    }
 
     int whiteEGFactorMat = 0, blackEGFactorMat = 0;
-    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++)
+    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++) {
         whiteEGFactorMat += EG_FACTOR_PIECE_VALS[pieceID] * pieceCounts[WHITE][pieceID];
-    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++)
         blackEGFactorMat += EG_FACTOR_PIECE_VALS[pieceID] * pieceCounts[BLACK][pieceID];
+    }
 
     // Compute endgame factor which is between 0 and EG_FACTOR_RES, inclusive
     int egFactor = EG_FACTOR_RES - (whiteEGFactorMat + blackEGFactorMat - EG_FACTOR_ALPHA) * EG_FACTOR_RES / EG_FACTOR_BETA;
@@ -238,21 +238,21 @@ int Eval::evaluate(Board &b) {
 
     // Bishop pair bonus
     if ((pieces[WHITE][BISHOPS] & LIGHT) && (pieces[WHITE][BISHOPS] & DARK)) {
-        whiteMaterial += BISHOP_PAIR_VALUE;
+        valueMg += BISHOP_PAIR_VALUE;
         valueEg += BISHOP_PAIR_VALUE;
     }
     if ((pieces[BLACK][BISHOPS] & LIGHT) && (pieces[BLACK][BISHOPS] & DARK)) {
-        blackMaterial += BISHOP_PAIR_VALUE;
+        valueMg -= BISHOP_PAIR_VALUE;
         valueEg -= BISHOP_PAIR_VALUE;
     }
 
     // MG and EG material
     valueMg += whiteMaterial;
     valueMg -= blackMaterial;
-    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++)
+    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++) {
         valueEg += PIECE_VALUES[EG][pieceID] * pieceCounts[WHITE][pieceID];
-    for (int pieceID = PAWNS; pieceID <= QUEENS; pieceID++)
         valueEg -= PIECE_VALUES[EG][pieceID] * pieceCounts[BLACK][pieceID];
+    }
 
     // Tempo bonus
     valueMg += (playerToMove == WHITE) ? TEMPO_VALUE : -TEMPO_VALUE;
@@ -915,13 +915,13 @@ int Eval::evaluate(Board &b) {
         }
     }
     // Reduce eval for lack of pawns
-    if (whiteMaterial - blackMaterial > 0
-     && whiteMaterial - blackMaterial <= PIECE_VALUES[MG][KNIGHTS]
+    if (whiteMaterial - blackMaterial >= 0
+     && whiteMaterial - blackMaterial <= PIECE_VALUES[EG][KNIGHTS]
      && pieceCounts[WHITE][PAWNS] <= 1) {
         if (pieceCounts[WHITE][PAWNS] == 0) {
-            if (whiteMaterial < PIECE_VALUES[MG][BISHOPS] + 50)
+            if (whiteMaterial < PIECE_VALUES[EG][BISHOPS])
                 scaleFactor = PAWNLESS_SCALING[0];
-            else if (blackMaterial <= PIECE_VALUES[MG][BISHOPS])
+            else if (blackMaterial <= PIECE_VALUES[EG][BISHOPS])
                 scaleFactor = PAWNLESS_SCALING[1];
             else
                 scaleFactor = PAWNLESS_SCALING[2];
@@ -931,12 +931,12 @@ int Eval::evaluate(Board &b) {
         }
     }
     if (blackMaterial - whiteMaterial > 0
-     && blackMaterial - whiteMaterial <= PIECE_VALUES[MG][KNIGHTS]
+     && blackMaterial - whiteMaterial <= PIECE_VALUES[EG][KNIGHTS]
      && pieceCounts[BLACK][PAWNS] <= 1) {
         if (pieceCounts[BLACK][PAWNS] == 0) {
-            if (blackMaterial < PIECE_VALUES[MG][BISHOPS] + 50)
+            if (blackMaterial < PIECE_VALUES[EG][BISHOPS])
                 scaleFactor = PAWNLESS_SCALING[0];
-            else if (whiteMaterial <= PIECE_VALUES[MG][BISHOPS])
+            else if (whiteMaterial <= PIECE_VALUES[EG][BISHOPS])
                 scaleFactor = PAWNLESS_SCALING[1];
             else
                 scaleFactor = PAWNLESS_SCALING[2];


### PR DESCRIPTION
- Don't treat bishop pair as material; this unnecessarily messes with scaling imo
- Include cases where whiteMaterial = blackMaterial for pawnless scaling
- Use EG values for pawnless scaling
- Some code cosmetics

bench: 2142576
922-821-1257 in 3000 games at 6+0.06 (11.70 +/- 9.47)
253-222-525 in 1000 games at 30+0.3 (10.77 +/- 14.83)
(My TCs halved ~ your TCs.)