### PR TITLE
Speedups by removing redundant looping

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -63,7 +63,7 @@ private:
 
 
 const int SEE_PIECE_VALS[6] = {100, 400, 400, 600, 1150, MATE_SCORE/2};
-const int EG_FACTOR_PIECE_VALS[5] = {50, 383, 387, 671, 1553};
+const int EG_FACTOR_PIECE_VALS[6] = {50, 383, 387, 671, 1553, 0};
 const int EG_FACTOR_ALPHA = 2340;
 const int EG_FACTOR_BETA = 6380;
 const int EG_FACTOR_RES = 1000;
@@ -94,9 +94,9 @@ const int MG = 0;
 const int EG = 1;
 
 // Material constants
-const int PIECE_VALUES[2][5] = {
-  {100, 392, 437, 662, 1351},
-  {136, 395, 447, 714, 1391}
+const int PIECE_VALUES[2][6] = {
+  {100, 392, 437, 662, 1351, 0},
+  {136, 395, 447, 714, 1391, 0}
 };
 const int KNOWN_WIN = PIECE_VALUES[EG][PAWNS] * 75;
 const int TB_WIN = PIECE_VALUES[EG][PAWNS] * 125;


### PR DESCRIPTION
Laldon heckling me to try to look at Laser. This might sate him.

BASE: bench 20
Nodes: 267403196
Time: 247505
Nodes/second: 1080395

TEST: bench 20
Nodes: 267403196
Time: 244482
Nodes/second: 1093754

SPEEDUP = 1.2365%

I seem to be able to reproduce the speedup, I imagine you can too.
It's small, but hey, take it or leave it :)