### PR TITLE
Fix GCC 8.1.0 warnings

### DIFF
--- a/board.cpp
+++ b/board.cpp
@@ -124,7 +124,7 @@ Board::~Board() {}
 
 Board Board::staticCopy() {
     Board b;
-    std::memcpy(&b, this, sizeof(Board));
+    std::memcpy(static_cast<void*>(&b), this, sizeof(Board));
     return b;
 }
 

--- a/evalhash.cpp
+++ b/evalhash.cpp
@@ -72,6 +72,6 @@ void EvalHash::init(uint64_t MB) {
 }
 
 void EvalHash::clear() {
-    std::memset(table, 0, size * sizeof(EvalHashEntry));
+    std::memset(static_cast<void*>(table), 0, size * sizeof(EvalHashEntry));
     keys = 0;
 }

--- a/hash.cpp
+++ b/hash.cpp
@@ -119,7 +119,7 @@ void Hash::init(uint64_t MB) {
 }
 
 void Hash::clear() {
-    std::memset(table, 0, size * sizeof(HashNode));
+    std::memset(static_cast<void*>(table), 0, size * sizeof(HashNode));
 }
 
 int Hash::estimateHashfull(uint8_t age) {


### PR DESCRIPTION
Fix for three -Wclass-memaccess warnings w/ MinGW-W64 GCC-8.1.0 inspired by https://github.com/01org/tbb/issues/54.
No functional change.

1769-1755-2476 in 6000 games at 6+0.06 (0.81 +/- 6.73)