### PR TITLE
Fix scaleFactor conflict

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -938,7 +938,7 @@ int Eval::evaluate(Board &b) {
                 else
                     scaleFactor = PAWNLESS_SCALING[2];
             }
-            else
+            else if (scaleFactor != OPPOSITE_BISHOP_SCALING[0])
                 scaleFactor = PAWNLESS_SCALING[3];
         }
     }


### PR DESCRIPTION
Corrects some cases when lack-of-pawns scaleFactor actually overwrites OCB scaleFactor with a higher one.
Same bench at low depths. Difference checked with example position (e.g. 7k/3pp3/5p2/5b2/8/2B1P3/3P1P2/K7 w - - 0 1).

760-706-1534 in 3000 games at 20+0.2 (6.25 +/- 8.68)
IMO this only gains a little at VLTC, but corrects an illogical behaviour.