### PR TITLE
Support for PEXT, better build system, fix all warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ LIBS    = -lpthread
 EXE     = Laser
 
 WFLAGS = -Wall -Wextra -Wshadow -ansi -pedantic -std=c++11
-CFLAGS = -DNDEBUG -O3 $(WFLAGS) -flto
+CFLAGS = -DNDEBUG -O3 $(WFLAGS) -flto -march=native
 RFLAGS = -DNDEBUG -O3 $(WFLAGS) -flto -static -static-libgcc -static-libstdc++
 PFLAGS = -DNDEBUG -O0 $(WFLAGS) -p -pg
 DFLAGS = -O0 $(WFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,26 +15,36 @@
 # along with Laser.  If not, see <http://www.gnu.org/licenses/>.
 
 CC      = g++
-CFLAGS  = -Wall -ansi -pedantic -std=c++11 -O3 -flto
-LDFLAGS = -lpthread
-OBJS    = bbinit.o board.o common.o eval.o evalhash.o hash.o search.o moveorder.o syzygy/tbprobe.o
-EXE     = laser
+SRC     = *.cpp syzygy/tbprobe.cpp
+LIBS    = -lpthread
+EXE     = Laser
 
-ifeq ($(USE_STATIC), true)
-	LDFLAGS += -static -static-libgcc -static-libstdc++
-endif
+WFLAGS = -Wall -Wextra -Wshadow -ansi -pedantic -std=c++11
+CFLAGS = -DNDEBUG -O3 $(WFLAGS) -flto
+RFLAGS = -DNDEBUG -O3 $(WFLAGS) -flto -static -static-libgcc -static-libstdc++
+PFLAGS = -DNDEBUG -O0 $(WFLAGS) -p -pg
+DFLAGS = -O0 $(WFLAGS)
 
-ifeq ($(BMI2), true)
-	CFLAGS  += -march=haswell
-endif
+POPCNTFLAGS = -DUSE_POPCNT -msse3 -mpopcnt
+PEXTFLAGS   = $(POPCNTFLAGS) -DUSE_PEXT -mbmi2
 
-all: uci
+popcnt:
+	$(CC) $(CFLAGS) $(SRC) $(LIBS) $(POPCNTFLAGS) -o $(EXE)
 
-uci: $(OBJS) uci.o
-	$(CC) -O3 -flto -o $(EXE)$(EXT) $^ $(LDFLAGS)
+nopopcnt:
+	$(CC) $(CFLAGS) $(SRC) $(LIBS) -o $(EXE)
 
-%.o: %.cpp
-	$(CC) -c $(CFLAGS) -x c++ $< -o $@
+pext:
+	$(CC) $(CFLAGS) $(SRC) $(LIBS) $(PEXTFLAGS) -o $(EXE)
 
-clean:
-	rm -f *.o syzygy/*.o $(EXE)$(EXT).exe $(EXE)$(EXT)
+release:
+	mkdir ../dist
+	$(CC) $(RFLAGS) $(SRC) $(LIBS) -o ../dist/$(EXE)$(VER)-x64-nopopcnt.exe
+	$(CC) $(RFLAGS) $(SRC) $(LIBS) $(POPCNTFLAGS) -o ../dist/$(EXE)$(VER)-x64-popcnt.exe
+	$(CC) $(RFLAGS) $(SRC) $(LIBS) $(PEXTFLAGS) -o ../dist/$(EXE)$(VER)-x64-pext.exe
+
+profile:
+	$(CC) $(PFLAGS) $(SRC) $(LIBS) $(POPCNT) -o $(EXE)
+
+debug:
+	$(CC) $(DFLAGS) $(SRC) $(LIBS) $(POPCNT) -o $(EXE)

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -26,14 +26,14 @@
 #include <immintrin.h> // for _pext_u64()
 #endif
 
-static uint64_t KnightAttacks[64];
-static uint64_t BishopAttacks[0x1480];
-static uint64_t RookAttacks[0x19000];
-static uint64_t KingAttacks[64];
+uint64_t KnightAttacks[64];
+uint64_t BishopAttacks[0x1480];
+uint64_t RookAttacks[0x19000];
+uint64_t KingAttacks[64];
 
-static uint64_t BishopMask[64], RookMask[64];
-static unsigned BishopShift[64], RookShift[64];
-static uint64_t *BishopAttacksPtr[64], *RookAttacksPtr[64];
+uint64_t BishopMask[64], RookMask[64];
+unsigned BishopShift[64], RookShift[64];
+uint64_t *BishopAttacksPtr[64], *RookAttacksPtr[64];
 
 constexpr uint64_t RookMagic[64] = {
     0xA180022080400230ull, 0x0040100040022000ull, 0x0080088020001002ull, 0x0080080280841000ull,

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -1,0 +1,209 @@
+/*
+    Laser, a UCI chess engine written in C++11.
+    Copyright 2015-2018 Jeffrey An and Michael An
+
+    Laser is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Laser is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Laser.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <cassert>
+#include <cstdint>
+
+#include "bbinit.h"
+#include "common.h"
+
+#ifdef USE_PEXT
+#include <immintrin.h> // for _pext_u64()
+#endif
+
+static uint64_t KnightAttacks[64];
+static uint64_t BishopAttacks[0x1480];
+static uint64_t RookAttacks[0x19000];
+static uint64_t KingAttacks[64];
+
+static uint64_t BishopMask[64], RookMask[64];
+static unsigned BishopShift[64], RookShift[64];
+static uint64_t *BishopAttacksPtr[64], *RookAttacksPtr[64];
+
+constexpr uint64_t RookMagic[64] = {
+    0xA180022080400230ull, 0x0040100040022000ull, 0x0080088020001002ull, 0x0080080280841000ull,
+    0x4200042010460008ull, 0x04800A0003040080ull, 0x0400110082041008ull, 0x008000A041000880ull,
+    0x10138001A080C010ull, 0x0000804008200480ull, 0x00010011012000C0ull, 0x0022004128102200ull,
+    0x000200081201200Cull, 0x202A001048460004ull, 0x0081000100420004ull, 0x4000800380004500ull,
+    0x0000208002904001ull, 0x0090004040026008ull, 0x0208808010002001ull, 0x2002020020704940ull,
+    0x8048010008110005ull, 0x6820808004002200ull, 0x0A80040008023011ull, 0x00B1460000811044ull,
+    0x4204400080008EA0ull, 0xB002400180200184ull, 0x2020200080100380ull, 0x0010080080100080ull,
+    0x2204080080800400ull, 0x0000A40080360080ull, 0x02040604002810B1ull, 0x008C218600004104ull,
+    0x8180004000402000ull, 0x488C402000401001ull, 0x4018A00080801004ull, 0x1230002105001008ull,
+    0x8904800800800400ull, 0x0042000C42003810ull, 0x008408110400B012ull, 0x0018086182000401ull,
+    0x2240088020C28000ull, 0x001001201040C004ull, 0x0A02008010420020ull, 0x0010003009010060ull,
+    0x0004008008008014ull, 0x0080020004008080ull, 0x0282020001008080ull, 0x50000181204A0004ull,
+    0x48FFFE99FECFAA00ull, 0x48FFFE99FECFAA00ull, 0x497FFFADFF9C2E00ull, 0x613FFFDDFFCE9200ull,
+    0xFFFFFFE9FFE7CE00ull, 0xFFFFFFF5FFF3E600ull, 0x0010301802830400ull, 0x510FFFF5F63C96A0ull,
+    0xEBFFFFB9FF9FC526ull, 0x61FFFEDDFEEDAEAEull, 0x53BFFFEDFFDEB1A2ull, 0x127FFFB9FFDFB5F6ull,
+    0x411FFFDDFFDBF4D6ull, 0x0801000804000603ull, 0x0003FFEF27EEBE74ull, 0x7645FFFECBFEA79Eull
+};
+
+constexpr uint64_t BishopMagic[64] = {
+    0xFFEDF9FD7CFCFFFFull, 0xFC0962854A77F576ull, 0x5822022042000000ull, 0x2CA804A100200020ull,
+    0x0204042200000900ull, 0x2002121024000002ull, 0xFC0A66C64A7EF576ull, 0x7FFDFDFCBD79FFFFull,
+    0xFC0846A64A34FFF6ull, 0xFC087A874A3CF7F6ull, 0x1001080204002100ull, 0x1810080489021800ull,
+    0x0062040420010A00ull, 0x5028043004300020ull, 0xFC0864AE59B4FF76ull, 0x3C0860AF4B35FF76ull,
+    0x73C01AF56CF4CFFBull, 0x41A01CFAD64AAFFCull, 0x040C0422080A0598ull, 0x4228020082004050ull,
+    0x0200800400E00100ull, 0x020B001230021040ull, 0x7C0C028F5B34FF76ull, 0xFC0A028E5AB4DF76ull,
+    0x0020208050A42180ull, 0x001004804B280200ull, 0x2048020024040010ull, 0x0102C04004010200ull,
+    0x020408204C002010ull, 0x02411100020080C1ull, 0x102A008084042100ull, 0x0941030000A09846ull,
+    0x0244100800400200ull, 0x4000901010080696ull, 0x0000280404180020ull, 0x0800042008240100ull,
+    0x0220008400088020ull, 0x04020182000904C9ull, 0x0023010400020600ull, 0x0041040020110302ull,
+    0xDCEFD9B54BFCC09Full, 0xF95FFA765AFD602Bull, 0x1401210240484800ull, 0x0022244208010080ull,
+    0x1105040104000210ull, 0x2040088800C40081ull, 0x43FF9A5CF4CA0C01ull, 0x4BFFCD8E7C587601ull,
+    0xFC0FF2865334F576ull, 0xFC0BF6CE5924F576ull, 0x80000B0401040402ull, 0x0020004821880A00ull,
+    0x8200002022440100ull, 0x0009431801010068ull, 0xC3FFB7DC36CA8C89ull, 0xC3FF8A54F4CA2C89ull,
+    0xFFFFFCFCFD79EDFFull, 0xFC0863FCCB147576ull, 0x040C000022013020ull, 0x2000104000420600ull,
+    0x0400000260142410ull, 0x0800633408100500ull, 0xFC087E8E4BB2F736ull, 0x43FF9E4EF4CA2C89ull
+};
+
+static int fileOf(int sq) {
+    assert(0 <= sq && sq < 64);
+    return sq % 8;
+}
+
+static int rankOf(int sq) {
+    assert(0 <= sq && sq < 64);
+    return sq / 8;
+}
+
+static int makeSquare(int rank, int file) {
+    assert(0 <= rank && rank < 8);
+    assert(0 <= file && file < 8);
+    return rank * 8 + file;
+}
+
+static int validCoordinate(int rank, int file) {
+    return 0 <= rank && rank < 8
+        && 0 <= file && file < 8;
+}
+
+static void setSquare(uint64_t *bb, int rank, int file){
+    if (validCoordinate(rank, file))
+        *bb |= 1ull << makeSquare(rank, file);
+}
+
+static int sliderIndex(uint64_t occupied, uint64_t mask, uint64_t magic, unsigned shift) {
+#ifdef USE_PEXT
+    (void)magic, (void)shift;  // Silence compiler warnings
+    return _pext_u64(occupied, mask);
+#else
+    return ((occupied & mask) * magic) >> shift;
+#endif
+}
+
+static uint64_t sliderAttacks(int sq, uint64_t occupied, const int delta[4][2]) {
+
+    int rank, file, dr, df;
+    uint64_t result = 0ull;
+
+    for (int i = 0; i < 4; i++) {
+
+        dr = delta[i][0], df = delta[i][1];
+
+        for (rank = rankOf(sq) + dr, file = fileOf(sq) + df;
+             validCoordinate(rank, file);
+             rank += dr, file += df) {
+
+            result ^= 1ull << makeSquare(rank, file);
+
+            if (occupied & (1ull << makeSquare(rank, file)))
+                break;
+        }
+    }
+
+    return result;
+}
+
+static void initSliderAttacks(int sq, uint64_t mask[64], const uint64_t magic[64],
+    unsigned shift[64], uint64_t *attacksPtr[64], const int delta[4][2]) {
+
+    uint64_t edges = ((RANK_1 | RANK_8) & ~RANKS[rankOf(sq)])
+                   | ((FILE_A | FILE_H) & ~FILES[fileOf(sq)]);
+
+    uint64_t occupied = 0ull;
+
+    mask[sq] = sliderAttacks(sq, 0, delta) & ~edges;
+
+    shift[sq] = 64 - count(mask[sq]);
+
+    if (sq != 63) attacksPtr[sq + 1] = attacksPtr[sq] + (1 << count(mask[sq]));
+
+    do {
+        int index = sliderIndex(occupied, mask[sq], magic[sq], shift[sq]);
+        attacksPtr[sq][index] = sliderAttacks(sq, occupied, delta);
+        occupied = (occupied - mask[sq]) & mask[sq];
+    } while (occupied);
+}
+
+void initAttacks() {
+
+    const int KnightDelta[8][2] = {{-2,-1}, {-2, 1}, {-1,-2}, {-1, 2},{ 1,-2}, { 1, 2}, { 2,-1}, { 2, 1}};
+    const int KingDelta[8][2]   = {{-1,-1}, {-1, 0}, {-1, 1}, { 0,-1},{ 0, 1}, { 1,-1}, { 1, 0}, { 1, 1}};
+    const int BishopDelta[4][2] = {{-1,-1}, {-1, 1}, { 1,-1}, { 1, 1}};
+    const int RookDelta[4][2]   = {{-1, 0}, { 0,-1}, { 0, 1}, { 1, 0}};
+
+    // A1 for the start of the tables
+    BishopAttacksPtr[0] = BishopAttacks;
+    RookAttacksPtr[0] = RookAttacks;
+
+    // Init attack tables for Knights & Kings
+    for (int sq = 0; sq < 64; sq++) {
+        for (int dir = 0; dir < 8; dir++) {
+            setSquare(&KnightAttacks[sq], rankOf(sq) + KnightDelta[dir][0], fileOf(sq) + KnightDelta[dir][1]);
+            setSquare(  &KingAttacks[sq], rankOf(sq) +   KingDelta[dir][0], fileOf(sq) +   KingDelta[dir][1]);
+        }
+    }
+
+    for (int sq = 0; sq < 64; sq++)
+        printf("%llu\n",KnightAttacks[sq]);
+
+    // Init attack tables for Bishops & Rooks (+ Queens)
+    for (int sq = 0; sq < 64; sq++) {
+        initSliderAttacks(sq, BishopMask, BishopMagic, BishopShift, BishopAttacksPtr, BishopDelta);
+        initSliderAttacks(sq,   RookMask,   RookMagic,   RookShift,   RookAttacksPtr,   RookDelta);
+    }
+}
+
+uint64_t knightAttacks(int sq) {
+    assert(0 <= sq && sq < 64);
+    return KnightAttacks[sq];
+}
+
+uint64_t bishopAttacks(int sq, uint64_t occupied) {
+    assert(0 <= sq && sq < 64);
+    int index = sliderIndex(occupied, BishopMask[sq], BishopMagic[sq], BishopShift[sq]);
+    return BishopAttacksPtr[sq][index];
+}
+
+uint64_t rookAttacks(int sq, uint64_t occupied) {
+    assert(0 <= sq && sq < 64);
+    int index = sliderIndex(occupied, RookMask[sq], RookMagic[sq], RookShift[sq]);
+    return RookAttacksPtr[sq][index];
+}
+
+uint64_t queenAttacks(int sq, uint64_t occupied) {
+    assert(0 <= sq && sq < 64);
+    return bishopAttacks(sq, occupied) | rookAttacks(sq, occupied);
+}
+
+uint64_t kingAttacks(int sq) {
+    assert(0 <= sq && sq < 64);
+    return KingAttacks[sq];
+}

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -170,10 +170,6 @@ void initAttacks() {
             setSquare(  &KingAttacks[sq], rankOf(sq) +   KingDelta[dir][0], fileOf(sq) +   KingDelta[dir][1]);
         }
     }
-
-    for (int sq = 0; sq < 64; sq++)
-        printf("%llu\n",KnightAttacks[sq]);
-
     // Init attack tables for Bishops & Rooks (+ Queens)
     for (int sq = 0; sq < 64; sq++) {
         initSliderAttacks(sq, BishopMask, BishopMagic, BishopShift, BishopAttacksPtr, BishopDelta);

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -1,0 +1,29 @@
+/*
+    Laser, a UCI chess engine written in C++11.
+    Copyright 2015-2018 Jeffrey An and Michael An
+
+    Laser is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Laser is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Laser.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+void initAttacks();
+
+uint64_t knightAttacks(int sq);
+uint64_t bishopAttacks(int sq, uint64_t occupied);
+uint64_t rookAttacks(int sq, uint64_t occupied);
+uint64_t queenAttacks(int sq, uint64_t occupied);
+uint64_t kingAttacks(int sq);

--- a/src/bbinit.cpp
+++ b/src/bbinit.cpp
@@ -16,60 +16,15 @@
     along with Laser.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "attacks.h"
 #include "bbinit.h"
-
-
-/**
- * @brief Our implementation of a xorshift generator as discovered by George
- * Marsaglia.
- * This specific implementation is not fully pseudorandom, but attempts to
- * create good magic number candidates by artifically increasing the number
- * of high bits.
- */
-static uint64_t mseed = 0, mstate = 0;
-uint64_t magicRNG() {
-    // Use "y" to achieve a larger number of high bits
-    uint64_t y = ((mstate << 57) | (mseed << 57)) >> 1;
-    mstate ^= mseed >> 17;
-    mstate ^= mstate << 3;
-
-    uint64_t temp = mseed;
-    mseed = mstate;
-    mstate = temp;
-
-    // But not too high, or they will overflow out once multiplied by the mask
-    return (y | (mseed ^ mstate)) >> 1;
-}
-
-// Shift amounts for Dumb7fill
-constexpr int NORTH_SOUTH_FILL = 8;
-constexpr int EAST_WEST_FILL = 1;
-constexpr int NE_SW_FILL = 9;
-constexpr int NW_SE_FILL = 7;
 
 // Dumb7fill methods, only used to initialize magic bitboard tables
 uint64_t fillRayRight(uint64_t rayPieces, uint64_t empty, int shift);
 uint64_t fillRayLeft(uint64_t rayPieces, uint64_t empty, int shift);
 
-// Masks the relevant rook or bishop occupancy bits for magic bitboards
-static uint64_t ROOK_MASK[64];
-static uint64_t BISHOP_MASK[64];
-// The full attack table containing all attack sets of bishops and rooks
-uint64_t *attackTable;
-// The magic values for bishops, one for each square
-MagicInfo magicBishops[64];
-// The magic values for rooks, one for each square
-MagicInfo magicRooks[64];
-
 // Lookup table for all squares in a line between the from and to squares
 uint64_t inBetweenSqs[64][64];
-
-uint64_t indexToMask64(int index, int nBits, uint64_t mask);
-uint64_t ratt(int sq, uint64_t block);
-uint64_t batt(int sq, uint64_t block);
-int magicMap(uint64_t masked, uint64_t magic, int nBits);
-uint64_t findMagic(int sq, int m, bool isBishop);
-
 
 // Initializes the 64x64 table, indexed by from and to square, of all
 // squares in a line between from and to
@@ -77,18 +32,18 @@ void initInBetweenTable() {
     for (int sq1 = 0; sq1 < 64; sq1++) {
         for (int sq2 = 0; sq2 < 64; sq2++) {
             // Check horizontal/vertical lines
-            uint64_t imaginaryRook = ratt(sq1, indexToBit(sq2));
+            uint64_t imaginaryRook = rookAttacks(sq1, indexToBit(sq2));
             // If the two squares are on a line
             if (imaginaryRook & indexToBit(sq2)) {
-                uint64_t imaginaryRook2 = ratt(sq2, indexToBit(sq1));
+                uint64_t imaginaryRook2 = rookAttacks(sq2, indexToBit(sq1));
                 // Set the bitboard of squares in between
                 inBetweenSqs[sq1][sq2] = imaginaryRook & imaginaryRook2;
             }
             else {
                 // Check diagonal lines
-                uint64_t imaginaryBishop = batt(sq1, indexToBit(sq2));
+                uint64_t imaginaryBishop = bishopAttacks(sq1, indexToBit(sq2));
                 if (imaginaryBishop & indexToBit(sq2)) {
-                    uint64_t imaginaryBishop2 = batt(sq2, indexToBit(sq1));
+                    uint64_t imaginaryBishop2 = bishopAttacks(sq2, indexToBit(sq1));
                     inBetweenSqs[sq1][sq2] = imaginaryBishop & imaginaryBishop2;
                 }
                 // If the squares are not on a line, the bitboard is empty
@@ -99,83 +54,6 @@ void initInBetweenTable() {
     }
 }
 
-
-/**
- * @brief Initializes the tables and values necessary for magic bitboards.
- * We use the "fancy" approach.
- * https://chessprogramming.wikispaces.com/Magic+Bitboards
- */
-void initMagicTables(uint64_t seed) {
-    // An arbitrarily chosen random number generator and seed
-    // The constant seed allows this process to be deterministic for optimization
-    // and debugging.
-    mstate = 74036198046ULL;
-    mseed = seed;
-    // Initialize the rook and bishop masks
-    for (int i = 0; i < 64; i++) {
-        // The relevant bits are everything except the edges
-        // However, we don't want to remove the edge that we are on
-        uint64_t relevantBits = ((~FILES[0] & ~FILES[7]) | FILES[i&7])
-                              & ((~RANKS[0] & ~RANKS[7]) | RANKS[i>>3]);
-        // The masks are rook and bishop attacks on an empty board
-        ROOK_MASK[i] = ratt(i, 0) & relevantBits;
-        BISHOP_MASK[i] = batt(i, 0) & relevantBits;
-    }
-    // The attack table has 107648 entries, found by summing the 2^(# relevant bits)
-    // for all squares of both bishops and rooks
-    attackTable = new uint64_t[107648];
-    // Keeps track of the start location of attack set arrays
-    int runningPtrLoc = 0;
-    // Initialize bishop magic values
-    for (int i = 0; i < 64; i++) {
-        uint64_t *tableStart = attackTable;
-        magicBishops[i].table = tableStart + runningPtrLoc;
-        magicBishops[i].mask = BISHOP_MASK[i];
-        magicBishops[i].magic = findMagic(i, NUM_BISHOP_BITS[i], true);
-        magicBishops[i].shift = 64 - NUM_BISHOP_BITS[i];
-        // We need 2^n array slots for a mask of n bits
-        runningPtrLoc += 1 << NUM_BISHOP_BITS[i];
-    }
-    // Initialize rook magic values
-    for (int i = 0; i < 64; i++) {
-        uint64_t *tableStart = attackTable;
-        magicRooks[i].table = tableStart + runningPtrLoc;
-        magicRooks[i].mask = ROOK_MASK[i];
-        magicRooks[i].magic = findMagic(i, NUM_ROOK_BITS[i], false);
-        magicRooks[i].shift = 64 - NUM_ROOK_BITS[i];
-        runningPtrLoc += 1 << NUM_ROOK_BITS[i];
-    }
-    // Set up the actual attack table, bishops first
-    for (int sq = 0; sq < 64; sq++) {
-        int nBits = NUM_BISHOP_BITS[sq];
-        uint64_t mask = BISHOP_MASK[sq];
-        // For each possible mask result
-        for (int i = 0; i < (1 << nBits); i++) {
-            // Find the pointer of where to store the attack sets
-            uint64_t *attTableLoc = magicBishops[sq].table;
-            // Find the actual masked bits from the mask index
-            uint64_t occ = indexToMask64(i, nBits, mask);
-            // Get the attack set for this masked occupancy
-            uint64_t attSet = batt(sq, occ);
-            // Do the mapping to get the location in the attack table where we
-            // store the attack set
-            int magicIndex = magicMap(occ, magicBishops[sq].magic, nBits);
-            attTableLoc[magicIndex] = attSet;
-        }
-    }
-    // Then rooks
-    for (int sq = 0; sq < 64; sq++) {
-        int nBits = NUM_ROOK_BITS[sq];
-        uint64_t mask = ROOK_MASK[sq];
-        for (int i = 0; i < (1 << nBits); i++) {
-            uint64_t *attTableLoc = magicRooks[sq].table;
-            uint64_t occ = indexToMask64(i, nBits, mask);
-            uint64_t attSet = ratt(sq, occ);
-            int magicIndex = magicMap(occ, magicRooks[sq].magic, nBits);
-            attTableLoc[magicIndex] = attSet;
-        }
-    }
-}
 
 // Dumb7Fill
 uint64_t fillRayRight(uint64_t rayPieces, uint64_t empty, int shift) {
@@ -212,111 +90,4 @@ uint64_t fillRayLeft(uint64_t rayPieces, uint64_t empty, int shift) {
     flood |= rayPieces = (rayPieces << shift) & empty;
     flood |=         (rayPieces << shift) & empty;
     return           (flood << shift) & borderMask;
-}
-
-
-//------------------------------------------------------------------------------
-//-----------------------------MAGIC BITBOARDS----------------------------------
-//------------------------------------------------------------------------------
-// This code is adapted from Tord Romstad's approach to finding magics,
-// available online at https://chessprogramming.wikispaces.com/Looking+for+Magics
-
-// Maps an index from 0 from 2^nBits - 1 into one of the
-// 2^nBits possible masks
-uint64_t indexToMask64(int index, int nBits, uint64_t mask) {
-    uint64_t result = 0;
-    // For each bit in the mask
-    for (int i = 0; i < nBits; i++) {
-        int j = bitScanForward(mask);
-        mask &= mask - 1;
-        // If this bit should be set...
-        if (index & indexToBit(i))
-            // Set it at the same position in the result
-            result |= indexToBit(j);
-    }
-    return result;
-}
-
-// Gets rook attacks using Dumb7Fill methods
-uint64_t ratt(int sq, uint64_t block) {
-    return fillRayRight(indexToBit(sq), ~block, NORTH_SOUTH_FILL) // south
-         | fillRayLeft(indexToBit(sq), ~block, NORTH_SOUTH_FILL)  // north
-         | fillRayLeft(indexToBit(sq), ~block, EAST_WEST_FILL)    // east
-         | fillRayRight(indexToBit(sq), ~block, EAST_WEST_FILL);  // west
-}
-
-// Gets bishop attacks using Dumb7Fill methods
-uint64_t batt(int sq, uint64_t block) {
-    return fillRayLeft(indexToBit(sq), ~block, NE_SW_FILL)   // northeast
-         | fillRayLeft(indexToBit(sq), ~block, NW_SE_FILL)   // northwest
-         | fillRayRight(indexToBit(sq), ~block, NE_SW_FILL)  // southwest
-         | fillRayRight(indexToBit(sq), ~block, NW_SE_FILL); // southeast
-}
-
-// Maps a mask using a candidate magic into an index nBits long
-inline int magicMap(uint64_t masked, uint64_t magic, int nBits) {
-    return (int) ((masked * magic) >> (64 - nBits));
-}
-
-/**
- * @brief Finds a magic number for the given square using trial and error.
- * @param sq The square to find the magic for.
- * @param iBits The length of the desired index, in bits
- * @param isBishop True for bishop magics, false for rook magics
- * @param magicRNG A random number generator to get magic candidates
- */
-uint64_t findMagic(int sq, int iBits, bool isBishop) {
-    uint64_t mask, maskedBits[4096], attSet[4096], used[4096], magic;
-    bool failed;
-
-    mask = isBishop ? BISHOP_MASK[sq] : ROOK_MASK[sq];
-    int nBits = count(mask);
-    // For each possible masked occupancy, get the attack set corresponding to
-    // that square and occupancy
-    for (int i = 0; i < (1 << nBits); i++) {
-        maskedBits[i] = indexToMask64(i, nBits, mask);
-        attSet[i] = isBishop ? batt(sq, maskedBits[i]) : ratt(sq, maskedBits[i]);
-    }
-    // Try 100 mill iterations before giving up
-    for (int k = 0; k < 100000000; k++) {
-        // Get a random magic candidate
-        // We make this random 64-bit integer sparse by &-ing 3 random numbers
-        // Sparse numbers are beneficial to keep the multiplied bits from
-        // bleeding together and becoming garbage
-        magic = magicRNG() & magicRNG() & magicRNG();
-        // We want a large number of high bits to get a higher success rate,
-        // since mask * magic is shifted by 64 - n bits, leaving n bits at the
-        // end. Thus, anything but the top 12 bits (for rooks in the corners) or
-        // less (for bishops) is garbage. Having a large number of high bits
-        // when multiplying by the full mask gives a better spread of values
-        // with different partial masks.
-        if (count((mask * magic) & 0xFFF0000000000000ULL) < 10)
-            continue;
-
-        // Clear the used table
-        for (int i = 0; i < 4096; i++)
-            used[i] = 0;
-        // Calculate the packed bits for every possible mask using this magic
-        // and see if any fail
-        failed = false;
-        for (int i = 0; !failed && i < (1 << nBits); i++) {
-            int mappedIndex = magicMap(maskedBits[i], magic, iBits);
-            // No collision, mark the index as used for the given attack set
-            if (!used[mappedIndex])
-                used[mappedIndex] = attSet[i];
-            // Otherwise, check for a constructive collsion, where a different
-            // occupancy has the same attack set.
-            // If the collision is not constructive, then we failed.
-            else if (used[mappedIndex] != attSet[i])
-                failed = true;
-        }
-        // If there were no collisions in all 2^nBits mappings, we have found
-        // a valid magic
-        if (!failed)
-            return magic;
-    }
-
-    // Otherwise we failed :(
-    // (this should never happen)
-    return 0;
 }

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -394,9 +394,7 @@ PieceMoveList Board::getPieceMoveList(int color) {
     while (knights) {
         int stSq = bitScanForward(knights);
         knights &= knights-1;
-        uint64_t nSq = getKnightSquares(stSq);
-
-        pml.add(PieceMoveInfo(KNIGHTS, stSq, nSq));
+        pml.add(PieceMoveInfo(KNIGHTS, stSq, knightAttacks(stSq)));
     }
 
     pml.starts[BISHOPS] = pml.size();
@@ -405,9 +403,7 @@ PieceMoveList Board::getPieceMoveList(int color) {
     while (bishops) {
         int stSq = bitScanForward(bishops);
         bishops &= bishops-1;
-        uint64_t bSq = getBishopSquares(stSq, occ | pieces[color][ROOKS]);
-
-        pml.add(PieceMoveInfo(BISHOPS, stSq, bSq));
+        pml.add(PieceMoveInfo(BISHOPS, stSq, bishopAttacks(stSq, occ | pieces[color][ROOKS])));
     }
 
     pml.starts[ROOKS] = pml.size();
@@ -415,9 +411,7 @@ PieceMoveList Board::getPieceMoveList(int color) {
     while (rooks) {
         int stSq = bitScanForward(rooks);
         rooks &= rooks-1;
-        uint64_t rSq = getRookSquares(stSq, occ | pieces[color][BISHOPS]);
-
-        pml.add(PieceMoveInfo(ROOKS, stSq, rSq));
+        pml.add(PieceMoveInfo(ROOKS, stSq, rookAttacks(stSq, occ | pieces[color][BISHOPS])));
     }
 
     pml.starts[QUEENS] = pml.size();
@@ -425,9 +419,7 @@ PieceMoveList Board::getPieceMoveList(int color) {
     while (queens) {
         int stSq = bitScanForward(queens);
         queens &= queens-1;
-        uint64_t qSq = getQueenSquares(stSq, occ);
-
-        pml.add(PieceMoveInfo(QUEENS, stSq, qSq));
+        pml.add(PieceMoveInfo(QUEENS, stSq, queenAttacks(stSq, occ)));
     }
 
     return pml;
@@ -481,7 +473,7 @@ void Board::getPseudoLegalQuiets(MoveList &quiets, int color) {
     addPawnMovesToList(quiets, color);
 
     int stsqK = bitScanForward(pieces[color][KINGS]);
-    uint64_t kingSqs = getKingSquares(stsqK);
+    uint64_t kingSqs = kingAttacks(stsqK);
     addMovesToList<MOVEGEN_QUIETS>(quiets, stsqK, kingSqs);
 }
 
@@ -499,7 +491,7 @@ void Board::getPseudoLegalCaptures(MoveList &captures, int color, bool includePr
     uint64_t otherPieces = allPieces[color^1];
 
     int kingStSq = bitScanForward(pieces[color][KINGS]);
-    uint64_t kingSqs = getKingSquares(kingStSq);
+    uint64_t kingSqs = kingAttacks(kingStSq);
     addMovesToList<MOVEGEN_CAPTURES>(captures, kingStSq, kingSqs, otherPieces);
 
     addPawnCapturesToList(captures, color, otherPieces, includePromotions);
@@ -639,11 +631,11 @@ void Board::getPseudoLegalChecks(MoveList &checks, int color) {
     }
 
     uint64_t knights = pieces[color][KNIGHTS] & kingParity;
-    uint64_t nAttackMap = getKnightSquares(kingSq);
+    uint64_t nAttackMap = knightAttacks(kingSq);
     while (knights) {
         int stsq = bitScanForward(knights);
         knights &= knights-1;
-        uint64_t nSq = getKnightSquares(stsq);
+        uint64_t nSq = knightAttacks(stsq);
         // Get any bishops, rooks, queens attacking king after knight has moved
         uint64_t xrays = getXRayPieceMap(color, kingSq, indexToBit(stsq), 0);
         // If still no xrayers are giving check, then we have no discovered
@@ -657,11 +649,11 @@ void Board::getPseudoLegalChecks(MoveList &checks, int color) {
 
     uint64_t occ = getOccupancy();
     uint64_t bishops = pieces[color][BISHOPS] & kingParity;
-    uint64_t bAttackMap = getBishopSquares(kingSq, occ);
+    uint64_t bAttackMap = bishopAttacks(kingSq, occ);
     while (bishops) {
         int stsq = bitScanForward(bishops);
         bishops &= bishops-1;
-        uint64_t bSq = getBishopSquares(stsq, occ);
+        uint64_t bSq = bishopAttacks(stsq, occ);
         uint64_t xrays = getXRayPieceMap(color, kingSq, indexToBit(stsq), 0);
         if (!(xrays & potentialXRay))
             bSq &= bAttackMap;
@@ -670,11 +662,11 @@ void Board::getPseudoLegalChecks(MoveList &checks, int color) {
     }
 
     uint64_t rooks = pieces[color][ROOKS];
-    uint64_t rAttackMap = getRookSquares(kingSq, occ);
+    uint64_t rAttackMap = rookAttacks(kingSq, occ);
     while (rooks) {
         int stsq = bitScanForward(rooks);
         rooks &= rooks-1;
-        uint64_t rSq = getRookSquares(stsq, occ);
+        uint64_t rSq = rookAttacks(stsq, occ);
         uint64_t xrays = getXRayPieceMap(color, kingSq, indexToBit(stsq), 0);
         if (!(xrays & potentialXRay))
             rSq &= rAttackMap;
@@ -683,11 +675,11 @@ void Board::getPseudoLegalChecks(MoveList &checks, int color) {
     }
 
     uint64_t queens = pieces[color][QUEENS];
-    uint64_t qAttackMap = getQueenSquares(kingSq, occ);
+    uint64_t qAttackMap = queenAttacks(kingSq, occ);
     while (queens) {
         int stsq = bitScanForward(queens);
         queens &= queens-1;
-        uint64_t qSq = getQueenSquares(stsq, occ) & qAttackMap;
+        uint64_t qSq = queenAttacks(stsq, occ) & qAttackMap;
 
         addMovesToList<MOVEGEN_QUIETS>(checks, stsq, qSq);
     }
@@ -706,7 +698,7 @@ void Board::getPseudoLegalCheckEscapes(MoveList &escapes, int color) {
 
     // If double check, we can only move the king
     if (count(otherPieces) >= 2) {
-        uint64_t kingSqs = getKingSquares(kingSq);
+        uint64_t kingSqs = kingAttacks(kingSq);
 
         addMovesToList<MOVEGEN_CAPTURES>(escapes, kingSq, kingSqs, allPieces[color^1]);
         addMovesToList<MOVEGEN_QUIETS>(escapes, kingSq, kingSqs);
@@ -722,53 +714,46 @@ void Board::getPseudoLegalCheckEscapes(MoveList &escapes, int color) {
     int attackerSq = bitScanForward(otherPieces);
     int attackerType = getPieceOnSquare(color^1, attackerSq);
     if (attackerType == BISHOPS)
-        xraySqs = getBishopSquares(attackerSq, occ);
+        xraySqs = bishopAttacks(attackerSq, occ);
     else if (attackerType == ROOKS)
-        xraySqs = getRookSquares(attackerSq, occ);
+        xraySqs = rookAttacks(attackerSq, occ);
     else if (attackerType == QUEENS)
-        xraySqs = getQueenSquares(attackerSq, occ);
+        xraySqs = queenAttacks(attackerSq, occ);
 
     addPieceMovesToList<MOVEGEN_CAPTURES>(escapes, color, otherPieces);
 
     int stsqK = bitScanForward(pieces[color][KINGS]);
-    uint64_t kingSqs = getKingSquares(stsqK);
+    uint64_t kingSqs = kingAttacks(stsqK);
     addMovesToList<MOVEGEN_CAPTURES>(escapes, stsqK, kingSqs, allPieces[color^1]);
 
     addPawnMovesToList(escapes, color);
+
     uint64_t knights = pieces[color][KNIGHTS];
     while (knights) {
         int stSq = bitScanForward(knights);
         knights &= knights-1;
-        uint64_t nSq = getKnightSquares(stSq);
-
-        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, nSq & xraySqs);
+        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, knightAttacks(stSq) & xraySqs);
     }
 
     uint64_t bishops = pieces[color][BISHOPS];
     while (bishops) {
         int stSq = bitScanForward(bishops);
         bishops &= bishops-1;
-        uint64_t bSq = getBishopSquares(stSq, occ);
-
-        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, bSq & xraySqs);
+        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, bishopAttacks(stSq, occ) & xraySqs);
     }
 
     uint64_t rooks = pieces[color][ROOKS];
     while (rooks) {
         int stSq = bitScanForward(rooks);
         rooks &= rooks-1;
-        uint64_t rSq = getRookSquares(stSq, occ);
-
-        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, rSq & xraySqs);
+        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, rookAttacks(stSq, occ) & xraySqs);
     }
 
     uint64_t queens = pieces[color][QUEENS];
     while (queens) {
         int stSq = bitScanForward(queens);
         queens &= queens-1;
-        uint64_t qSq = getQueenSquares(stSq, occ);
-
-        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, qSq & xraySqs);
+        addMovesToList<MOVEGEN_QUIETS>(escapes, stSq, queenAttacks(stSq, occ) & xraySqs);
     }
 
     addMovesToList<MOVEGEN_QUIETS>(escapes, stsqK, kingSqs);
@@ -889,13 +874,12 @@ void Board::addPawnCapturesToList(MoveList &captures, int color, uint64_t otherP
 
 template <bool isCapture>
 void Board::addPieceMovesToList(MoveList &moves, int color, uint64_t otherPieces) {
+
     uint64_t knights = pieces[color][KNIGHTS];
     while (knights) {
         int stSq = bitScanForward(knights);
         knights &= knights-1;
-        uint64_t nSq = getKnightSquares(stSq);
-
-        addMovesToList<isCapture>(moves, stSq, nSq, otherPieces);
+        addMovesToList<isCapture>(moves, stSq, knightAttacks(stSq), otherPieces);
     }
 
     uint64_t occ = getOccupancy();
@@ -903,27 +887,21 @@ void Board::addPieceMovesToList(MoveList &moves, int color, uint64_t otherPieces
     while (bishops) {
         int stSq = bitScanForward(bishops);
         bishops &= bishops-1;
-        uint64_t bSq = getBishopSquares(stSq, occ);
-
-        addMovesToList<isCapture>(moves, stSq, bSq, otherPieces);
+        addMovesToList<isCapture>(moves, stSq, bishopAttacks(stSq, occ), otherPieces);
     }
 
     uint64_t rooks = pieces[color][ROOKS];
     while (rooks) {
         int stSq = bitScanForward(rooks);
         rooks &= rooks-1;
-        uint64_t rSq = getRookSquares(stSq, occ);
-
-        addMovesToList<isCapture>(moves, stSq, rSq, otherPieces);
+        addMovesToList<isCapture>(moves, stSq, rookAttacks(stSq, occ), otherPieces);
     }
 
     uint64_t queens = pieces[color][QUEENS];
     while (queens) {
         int stSq = bitScanForward(queens);
         queens &= queens-1;
-        uint64_t qSq = getQueenSquares(stSq, occ);
-
-        addMovesToList<isCapture>(moves, stSq, qSq, otherPieces);
+        addMovesToList<isCapture>(moves, stSq, queenAttacks(stSq, occ), otherPieces);
     }
 }
 
@@ -1032,8 +1010,8 @@ uint64_t Board::getXRayPieceMap(int color, int sq, uint64_t blockerStart, uint64
     uint64_t rooks = pieces[color][ROOKS];
     uint64_t queens = pieces[color][QUEENS];
 
-    uint64_t xRayMap = (getBishopSquares(sq, occ) & (bishops | queens))
-                     | (getRookSquares(sq, occ) & (rooks | queens));
+    uint64_t xRayMap = (bishopAttacks(sq, occ) & (bishops | queens))
+                     | (  rookAttacks(sq, occ) & (  rooks | queens));
 
     return (xRayMap & ~blockerStart);
 }
@@ -1058,10 +1036,10 @@ uint64_t Board::getAttackMap(int color, int sq) {
                      ? getBPawnCaptures(indexToBit(sq))
                      : getWPawnCaptures(indexToBit(sq));
     return (pawnCap & pieces[color][PAWNS])
-         | (getKnightSquares(sq) & pieces[color][KNIGHTS])
-         | (getBishopSquares(sq, occ) & (pieces[color][BISHOPS] | pieces[color][QUEENS]))
-         | (getRookSquares(sq, occ) & (pieces[color][ROOKS] | pieces[color][QUEENS]))
-         | (getKingSquares(sq) & pieces[color][KINGS]);
+         | (knightAttacks(sq) & pieces[color][KNIGHTS])
+         | (bishopAttacks(sq, occ) & (pieces[color][BISHOPS] | pieces[color][QUEENS]))
+         | (rookAttacks(sq, occ) & (pieces[color][ROOKS] | pieces[color][QUEENS]))
+         | (kingAttacks(sq) & pieces[color][KINGS]);
 }
 
 // Get all pieces of both colors attacking a square
@@ -1069,10 +1047,10 @@ uint64_t Board::getAttackMap(int sq) {
     uint64_t occ = getOccupancy();
     return (getBPawnCaptures(indexToBit(sq)) & pieces[WHITE][PAWNS])
          | (getWPawnCaptures(indexToBit(sq)) & pieces[BLACK][PAWNS])
-         | (getKnightSquares(sq) & (pieces[WHITE][KNIGHTS] | pieces[BLACK][KNIGHTS]))
-         | (getBishopSquares(sq, occ) & (pieces[WHITE][BISHOPS] | pieces[WHITE][QUEENS] | pieces[BLACK][BISHOPS] | pieces[BLACK][QUEENS]))
-         | (getRookSquares(sq, occ) & (pieces[WHITE][ROOKS] | pieces[WHITE][QUEENS] | pieces[BLACK][ROOKS] | pieces[BLACK][QUEENS]))
-         | (getKingSquares(sq) & (pieces[WHITE][KINGS] | pieces[BLACK][KINGS]));
+         | (knightAttacks(sq) & (pieces[WHITE][KNIGHTS] | pieces[BLACK][KNIGHTS]))
+         | (bishopAttacks(sq, occ) & (pieces[WHITE][BISHOPS] | pieces[WHITE][QUEENS] | pieces[BLACK][BISHOPS] | pieces[BLACK][QUEENS]))
+         | (rookAttacks(sq, occ) & (pieces[WHITE][ROOKS] | pieces[WHITE][QUEENS] | pieces[BLACK][ROOKS] | pieces[BLACK][QUEENS]))
+         | (kingAttacks(sq) & (pieces[WHITE][KINGS] | pieces[BLACK][KINGS]));
 }
 
 // Given the on a given square, used to get either the piece moving or the
@@ -1094,7 +1072,7 @@ bool Board::isCheckMove(int color, Move m) {
 
     // Special case for castling
     if (isCastle(m)) {
-        uint64_t attackMap = getRookSquares(kingSq, getOccupancy() ^ indexToBit(getStartSq(m)));
+        uint64_t attackMap = rookAttacks(kingSq, getOccupancy() ^ indexToBit(getStartSq(m)));
         int rookEnd = 0;
         switch (getEndSq(m)) {
             case 6: // white kside
@@ -1128,16 +1106,16 @@ bool Board::isCheckMove(int color, Move m) {
                 : getWPawnCaptures(indexToBit(kingSq));
             break;
         case KNIGHTS:
-            attackMap = getKnightSquares(kingSq);
+            attackMap = knightAttacks(kingSq);
             break;
         case BISHOPS:
-            attackMap = getBishopSquares(kingSq, occ);
+            attackMap = bishopAttacks(kingSq, occ);
             break;
         case ROOKS:
-            attackMap = getRookSquares(kingSq, occ);
+            attackMap = rookAttacks(kingSq, occ);
             break;
         case QUEENS:
-            attackMap = getQueenSquares(kingSq, occ);
+            attackMap = queenAttacks(kingSq, occ);
             break;
         case KINGS:
             // keep attackMap 0
@@ -1168,15 +1146,15 @@ bool Board::isCheckMove(int color, Move m) {
  * Algorithm from http://chessprogramming.wikispaces.com/X-ray+Attacks+%28Bitboards%29#ModifyingOccupancy
  */
 uint64_t Board::getRookXRays(int sq, uint64_t occ, uint64_t blockers) {
-    uint64_t attacks = getRookSquares(sq, occ);
+    uint64_t attacks = rookAttacks(sq, occ);
     blockers &= attacks;
-    return attacks ^ getRookSquares(sq, occ ^ blockers);
+    return attacks ^ rookAttacks(sq, occ ^ blockers);
 }
 
 uint64_t Board::getBishopXRays(int sq, uint64_t occ, uint64_t blockers) {
-    uint64_t attacks = getBishopSquares(sq, occ);
+    uint64_t attacks = bishopAttacks(sq, occ);
     blockers &= attacks;
-    return attacks ^ getBishopSquares(sq, occ ^ blockers);
+    return attacks ^ bishopAttacks(sq, occ ^ blockers);
 }
 
 /*
@@ -1242,10 +1220,10 @@ bool Board::isInsufficientMaterial() {
 void Board::getCheckMaps(int color, uint64_t *checkMaps) {
     int kingSq = bitScanForward(pieces[color][KINGS]);
     uint64_t occ = getOccupancy();
-    checkMaps[KNIGHTS-1] = getKnightSquares(kingSq);
-    checkMaps[BISHOPS-1] = getBishopSquares(kingSq, occ);
-    checkMaps[ROOKS-1] = getRookSquares(kingSq, occ);
-    checkMaps[QUEENS-1] = getQueenSquares(kingSq, occ);
+    checkMaps[KNIGHTS-1] = knightAttacks(kingSq);
+    checkMaps[BISHOPS-1] = bishopAttacks(kingSq, occ);
+    checkMaps[  ROOKS-1] = rookAttacks(kingSq, occ);
+    checkMaps[ QUEENS-1] = queenAttacks(kingSq, occ);
 }
 
 
@@ -1447,26 +1425,6 @@ uint64_t Board::getWPawnCaptures(uint64_t pawns) {
 
 uint64_t Board::getBPawnCaptures(uint64_t pawns) {
     return getBPawnLeftCaptures(pawns) | getBPawnRightCaptures(pawns);
-}
-
-inline uint64_t Board::getKnightSquares(int single) {
-    return knightAttacks(single);
-}
-
-uint64_t Board::getBishopSquares(int single, uint64_t occ) {
-    return bishopAttacks(single, occ);
-}
-
-uint64_t Board::getRookSquares(int single, uint64_t occ) {
-    return rookAttacks(single, occ);
-}
-
-uint64_t Board::getQueenSquares(int single, uint64_t occ) {
-    return queenAttacks(single, occ);
-}
-
-uint64_t Board::getKingSquares(int single) {
-    return kingAttacks(single);
 }
 
 inline uint64_t Board::getOccupancy() {

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -20,11 +20,12 @@
 #include <cstring>
 #include <random>
 #include <string>
+
+#include "attacks.h"
 #include "board.h"
 #include "bbinit.h"
 #include "eval.h"
 #include "uci.h"
-
 
 constexpr uint64_t WHITE_KSIDE_PASSTHROUGH_SQS = indexToBit(5) | indexToBit(6);
 constexpr uint64_t WHITE_QSIDE_PASSTHROUGH_SQS = indexToBit(1) | indexToBit(2) | indexToBit(3);
@@ -46,11 +47,6 @@ void initZobristTable() {
     startPosZobristKey = b.getZobristKey();
     delete[] mailbox;
 }
-
-// Magic tables, initialized in bbinit.cpp
-extern uint64_t *attackTable;
-extern MagicInfo magicBishops[64];
-extern MagicInfo magicRooks[64];
 
 // Precalculated bitboard tables
 extern uint64_t inBetweenSqs[64][64];
@@ -1454,37 +1450,23 @@ uint64_t Board::getBPawnCaptures(uint64_t pawns) {
 }
 
 inline uint64_t Board::getKnightSquares(int single) {
-    return KNIGHTMOVES[single];
+    return knightAttacks(single);
 }
 
 uint64_t Board::getBishopSquares(int single, uint64_t occ) {
-#ifdef USE_PEXT
-    return _pext_u64(occ, magicBishops[single].mask);
-#else
-    occ &= magicBishops[single].mask;
-    occ *= magicBishops[single].magic;
-    occ >>= magicBishops[single].shift;
-    return magicBishops[single].table[occ];
-#endif
+    return bishopAttacks(single, occ);
 }
 
 uint64_t Board::getRookSquares(int single, uint64_t occ) {
-#ifdef USE_PEXT
-    return _pext_u64(occ, magicRooks[single].mask);
-#else
-    occ &= magicRooks[single].mask;
-    occ *= magicRooks[single].magic;
-    occ >>= magicRooks[single].shift;
-    return magicRooks[single].table[occ];
-#endif
+    return rookAttacks(single, occ);
 }
 
 uint64_t Board::getQueenSquares(int single, uint64_t occ) {
-    return getBishopSquares(single, occ) | getRookSquares(single, occ);
+    return queenAttacks(single, occ);
 }
 
 uint64_t Board::getKingSquares(int single) {
-    return KINGMOVES[single];
+    return kingAttacks(single);
 }
 
 inline uint64_t Board::getOccupancy() {

--- a/src/board.h
+++ b/src/board.h
@@ -101,8 +101,7 @@ public:
     void getPseudoLegalCheckEscapes(MoveList &escapes, int color);
 
     // Get a bitboard of all xray-ers attacking a square if a blocker has been moved or removed
-    uint64_t getXRayPieceMap(int color, int sq, int blockerColor,
-        uint64_t blockerStart, uint64_t blockerEnd);
+    uint64_t getXRayPieceMap(int color, int sq, uint64_t blockerStart, uint64_t blockerEnd);
     // Get a bitboard of all xray-ers attacking a square with no blocker removed
     //uint64_t getInitXRays(int color, int sq);
     // Get all pieces of that color attacking the square

--- a/src/board.h
+++ b/src/board.h
@@ -199,10 +199,6 @@ private:
     uint64_t getBPawnLeftCaptures(uint64_t pawns);
     uint64_t getWPawnRightCaptures(uint64_t pawns);
     uint64_t getBPawnRightCaptures(uint64_t pawns);
-    uint64_t getKnightSquares(int single);
-    uint64_t getBishopSquares(int single, uint64_t occ);
-    uint64_t getRookSquares(int single, uint64_t occ);
-    uint64_t getQueenSquares(int single, uint64_t occ);
     uint64_t getOccupancy();
     int epVictimSquare(int victimColor, uint16_t file);
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -20,9 +20,6 @@
 
 #include "common.h"
 
-// Move promotion flags
-const int PROMO[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4};
-
 int bitScanForward(uint64_t bb) {
     assert(bb);  // lsb(0) is undefined
     return __builtin_ctzll(bb);

--- a/src/common.h
+++ b/src/common.h
@@ -23,8 +23,6 @@
 #include <chrono>
 #include <string>
 
-#define USE_INLINE_ASM true
-
 constexpr int WHITE = 0;
 constexpr int BLACK = 1;
 constexpr int PAWNS = 0;
@@ -52,7 +50,6 @@ uint64_t getTimeElapsed(ChessTime startTime);
 int bitScanForward(uint64_t bb);
 int bitScanReverse(uint64_t bb);
 int count(uint64_t bb);
-uint64_t flipAcrossRanks(uint64_t bb);
 
 // Converts square number to bitboard
 inline constexpr uint64_t indexToBit(int sq) {

--- a/src/common.h
+++ b/src/common.h
@@ -79,7 +79,6 @@ constexpr uint16_t MOVE_PROMO_N = 0x8;
 constexpr uint16_t MOVE_PROMO_B = 0x9;
 constexpr uint16_t MOVE_PROMO_R = 0xA;
 constexpr uint16_t MOVE_PROMO_Q = 0xB;
-extern const int PROMO[16];
 
 inline Move encodeMove(int startSq, int endSq) {
     return (endSq << 6) | startSq;
@@ -106,6 +105,7 @@ inline int getEndSq(Move m) {
 }
 
 inline int getPromotion(Move m) {
+    static const int PROMO[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4};
     return PROMO[m >> 12];
 }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -19,6 +19,8 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+
+#include "attacks.h"
 #include "bbinit.h"
 #include "board.h"
 #include "common.h"
@@ -369,8 +371,8 @@ int Eval::evaluate(Board &b) {
     //------------------------------King Safety---------------------------------
     int kingSq[2] = {bitScanForward(pieces[WHITE][KINGS]),
                      bitScanForward(pieces[BLACK][KINGS])};
-    uint64_t kingNeighborhood[2] = {b.getKingSquares(kingSq[WHITE]),
-                                    b.getKingSquares(kingSq[BLACK])};
+    uint64_t kingNeighborhood[2] = {kingAttacks(kingSq[WHITE]),
+                                    kingAttacks(kingSq[BLACK])};
 
     // Calculate king piece square table scores
     psqtScores[WHITE] += PSQT[WHITE][KINGS][kingSq[WHITE]];
@@ -911,7 +913,7 @@ int Eval::evaluate(Board &b) {
         if (!(FILES[f] & pieces[WHITE][PAWNS]))
             blackPawnScore += bonus;
     }
-    
+
     valueMg += decEvalMg(whitePawnScore) - decEvalMg(blackPawnScore);
     valueEg += decEvalEg(whitePawnScore) - decEvalEg(blackPawnScore);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -75,14 +75,12 @@ int main(int argc, char **argv) {
 
     string input;
     std::vector<string> inputVector;
-    string name = "Laser";
-    string version = "1.7 beta";
     string author = "Jeffrey An and Michael An";
     std::thread searchThread;
 
     Board board = fenToBoard(STARTPOS);
 
-    cout << name << " " << version << " by " << author << endl;
+    cout << VERSION_ID << " by " << author << endl;
 
     // Run benchmark from command line with given depth
     if (argc > 1 && strcmp(argv[1], "bench") == 0) {
@@ -101,7 +99,7 @@ int main(int argc, char **argv) {
             continue;
 
         if (input == "uci") {
-            cout << "id name " << name << " " << version << endl;
+            cout << "id name " << LASER_VERSION << endl;
             cout << "id author " << author << endl;
             cout << "option name Threads type spin default " << DEFAULT_THREADS
                  << " min " << MIN_THREADS << " max " << MAX_THREADS << endl;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -26,6 +26,7 @@
 #include <thread>
 #include <random>
 
+#include "attacks.h"
 #include "common.h"
 #include "bbinit.h"
 #include "board.h"
@@ -62,7 +63,7 @@ extern std::atomic<bool> stopSignal;
 
 
 int main(int argc, char **argv) {
-    initMagicTables(2563762638929852183ULL);
+    initAttacks();
     initEvalTables();
     initDistances();
     initZobristTable();

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,6 +22,16 @@
 #include <cstdint>
 #include <string>
 
+#define VERSION_ID "Laser 1.7 beta"
+
+#if defined(USE_PEXT)
+    #define LASER_VERSION VERSION_ID" (PEXT)"
+#elif defined(USE_POPCNT)
+    #define LASER_VERSION VERSION_ID" (POPCNT)"
+#else
+    #define LASER_VERSION VERSION_ID
+#endif
+
 constexpr uint64_t DEFAULT_HASH_SIZE = 16;
 constexpr uint64_t MIN_HASH_SIZE = 1;
 constexpr uint64_t MAX_HASH_SIZE = 1024 * 1024;


### PR DESCRIPTION
Lot of stuff in this patch, but it has to be all together really ...

    Report POPCNT/PEXT builds to the UCI interface
    Add nopopcnt, popcnt, pext, and debug targets to the Makefile
    Support for PEXT magic index computations
    Rewrite Magic structures to be the smallest form possible
    Cleanup bbinit.h to match changes to move generation
    Enable more warning flags in the Makefile
    Cleanup warnings found in board.cpp and search.cpp
