### PR TITLE
Use GCC Intrinsics & Add Proper POPCNT Build Support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,10 @@ ifeq ($(USE_STATIC), true)
 	LDFLAGS += -static -static-libgcc -static-libstdc++
 endif
 
+ifneq ($(NOPOPCNT), true)
+	CFLAGS  += -msse3 -mpopcnt
+endif
+
 ifeq ($(BMI2), true)
 	CFLAGS  += -march=haswell
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@
 # along with Laser.  If not, see <http://www.gnu.org/licenses/>.
 
 CC      = g++
-CFLAGS  = -Wall -ansi -pedantic -std=c++11 -O3 -flto
+CFLAGS  = -Wall -DNDEBUG -ansi -pedantic -std=c++11 -O3 -flto
 LDFLAGS = -lpthread
 OBJS    = bbinit.o board.o common.o eval.o evalhash.o hash.o search.o moveorder.o syzygy/tbprobe.o
 EXE     = laser

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -16,78 +16,22 @@
     along with Laser.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cassert>
+
 #include "common.h"
 
-// Move promotion flags
-const int PROMO[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4};
-
-// Used for bit-scan reverse
-constexpr int index64[64] = {
-0,  47,  1, 56, 48, 27,  2, 60,
-57, 49, 41, 37, 28, 16,  3, 61,
-54, 58, 35, 52, 50, 42, 21, 44,
-38, 32, 29, 23, 17, 11,  4, 62,
-46, 55, 26, 59, 40, 36, 15, 53,
-34, 51, 20, 43, 31, 22, 10, 45,
-25, 39, 14, 33, 19, 30,  9, 24,
-13, 18,  8, 12,  7,  6,  5, 63 };
-
-// BSF and BSR algorithms from https://chessprogramming.wikispaces.com/BitScan
-// GCC compiler intrinsics seem to be slower in some cases, even the compiled
-// with optimization / intrinsic flags...
 int bitScanForward(uint64_t bb) {
-    #if USE_INLINE_ASM
-        asm ("bsfq %1, %0" : "=r" (bb) : "r" (bb));
-        return (int) bb;
-    #else
-        uint64_t debruijn64 = 0x03f79d71b4cb0a89;
-        int i = (int)(((bb ^ (bb-1)) * debruijn64) >> 58);
-        return index64[i];
-    #endif
+    assert(bb);  // ctz(0) is undefined
+    return __builtin_ctzll(bb);
 }
 
 int bitScanReverse(uint64_t bb) {
-    #if USE_INLINE_ASM
-        asm ("bsrq %1, %0" : "=r" (bb) : "r" (bb));
-        return (int) bb;
-    #else
-        uint64_t debruijn64 = 0x03f79d71b4cb0a89;
-        bb |= bb >> 1;
-        bb |= bb >> 2;
-        bb |= bb >> 4;
-        bb |= bb >> 8;
-        bb |= bb >> 16;
-        bb |= bb >> 32;
-        return index64[(int) ((bb * debruijn64) >> 58)];
-    #endif
+    assert(bb);  // clz(0) is undefined
+    return __builtin_clzll(bb) ^ 63;
 }
 
 int count(uint64_t bb) {
-    #if USE_INLINE_ASM
-        asm ("popcntq %1, %0" : "=r" (bb) : "r" (bb));
-        return (int) bb;
-    #else
-        bb = bb - ((bb >> 1) & 0x5555555555555555);
-        bb = (bb & 0x3333333333333333) + ((bb >> 2) & 0x3333333333333333);
-        bb = (((bb + (bb >> 4)) & 0x0F0F0F0F0F0F0F0F) * 0x0101010101010101) >> 56;
-        return (int) bb;
-    #endif
-}
-
-// Flips a board across the middle ranks, the way perspective is
-// flipped from white to black and vice versa
-// Parallel-prefix algorithm from
-// http://chessprogramming.wikispaces.com/Flipping+Mirroring+and+Rotating
-uint64_t flipAcrossRanks(uint64_t bb) {
-    #if USE_INLINE_ASM
-        asm ("bswapq %0" : "=r" (bb) : "0" (bb));
-        return bb;
-    #else
-        bb = ((bb >>  8) & 0x00FF00FF00FF00FF) | ((bb & 0x00FF00FF00FF00FF) <<  8);
-        bb = ((bb >> 16) & 0x0000FFFF0000FFFF) | ((bb & 0x0000FFFF0000FFFF) << 16);
-        bb =  (bb >> 32) | (bb << 32);
-        return bb;
-    #endif
+    return __builtin_popcountll(bb);
 }
 
 // Given a start time_point, returns the seconds elapsed using C++11's

--- a/src/common.h
+++ b/src/common.h
@@ -52,7 +52,6 @@ uint64_t getTimeElapsed(ChessTime startTime);
 int bitScanForward(uint64_t bb);
 int bitScanReverse(uint64_t bb);
 int count(uint64_t bb);
-uint64_t flipAcrossRanks(uint64_t bb);
 
 // Converts square number to bitboard
 inline constexpr uint64_t indexToBit(int sq) {
@@ -82,7 +81,6 @@ constexpr uint16_t MOVE_PROMO_N = 0x8;
 constexpr uint16_t MOVE_PROMO_B = 0x9;
 constexpr uint16_t MOVE_PROMO_R = 0xA;
 constexpr uint16_t MOVE_PROMO_Q = 0xB;
-extern const int PROMO[16];
 
 inline Move encodeMove(int startSq, int endSq) {
     return (endSq << 6) | startSq;
@@ -109,7 +107,8 @@ inline int getEndSq(Move m) {
 }
 
 inline int getPromotion(Move m) {
-    return PROMO[m >> 12];
+    const int Promo[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4};
+    return Promo[m >> 12];
 }
 
 inline bool isPromotion(Move m) {


### PR DESCRIPTION
NPS values are only important pair-wise, since the pairings are run in parallel.
Each pairwise comparison is the average of 4 runs of the following ...
`` ./binary bench <depth> |tail -1 ``

Testing under Ubuntu 18.04 with Ryzen 1950x (bench 20)
```
master-gcc-7 vs patch-gcc-7 : 963,238 NPS vs 977,080 NPS [[  PATCH GCC 8 ]]
```

Testing under Windows 7 with Quad Core I5 (bench 16)
```
master-gcc-7 vs patch-gcc-7 : 901,008 NPS vs 881,156 NPS [[ MASTER GCC 7 ]]
master-gcc-8 vs patch-gcc-7 : 899,693 NPS vs 877,507 NPS [[ MASTER GCC 8 ]]

master-gcc-7 vs patch-gcc-8 : 894,181 NPS vs 905,963 NPS [[  PATCH GCC 8 ]]
master-gcc-8 vs patch-gcc-8 : 906,821 NPS vs 916,612 NPS [[  PATCH GCC 8 ]]
```

Under gcc-8, using intrinsic with the additional compilation flags produces a faster binary.
The question are 1) why is gcc-8 faster, and 2) why are intrinsic faster? (I've already proven via assembly dumps that the same # of popcnt, bsf, bsr instructions are generated.

1) Its not, or if so, only slightly. Using the above testing setup, I found the NPS for gcc7 with current master to be 901437, and using gcc8 to be 903316. An (almost) immeasurable change.

2) I think its fair to say now that gcc7 produces suboptimal machine code when dealing with the sse3 instruction set -- but when we look at gcc8, the intrinsics are faster because firstly, the compiler can do a better job than your inline assembly, and secondly, you are not passing the correct flags to enable compilation optimizations when looking at a machine with popcnt support.
