### PR TITLE
Force exit when input pipes close

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -91,7 +91,6 @@ int main(int argc, char **argv) {
     }
 
     while (getline(std::cin, input)) {
-
         stringToLowerCase(input);
         inputVector = split(input, ' ');
         std::cin.clear();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -90,8 +90,8 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    while (true) {
-        getline(std::cin, input);
+    while (getline(std::cin, input)) {
+
         stringToLowerCase(input);
         inputVector = split(input, ' ');
         std::cin.clear();


### PR DESCRIPTION
This fixes support for machines on OpenBench.

It breaks feeding Laser a string of commands like follows ...
`` ./laser.exe < myMagicalListOfFunPositionsToSearch.txt``

If you are not okay with that breaking, then you can look at how to find out of std::cin is simply EOF, or has closed all together.